### PR TITLE
docs: add agent instructions (AGENTS.md, CLAUDE.md) and contributor/r…

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,190 @@
+# AGENTS.md
+
+Canonical instructions for AI coding agents (Claude Code, Cursor, Copilot, Codex, etc.)
+working in this repository. Human contributors: see [CONTRIBUTING.md](./CONTRIBUTING.md).
+
+Claude Code also reads [CLAUDE.md](./CLAUDE.md), which holds the behavioral rules and
+points back here for project context.
+
+---
+
+## What this project is
+
+**Bread UI Kit** (`@breadcoop/ui`) is the shared React + TypeScript **component library**
+for the Bread Coop frontend. It ships brand styling (Tailwind v4 theme, fonts, colors),
+typography, buttons, navbar/footer, auth + wallet UI, and a handful of web3 hooks.
+
+It is **not an app** — it has no routes, no backend, and no deploy target. Its job is to
+be a stable, well-typed package that the consumer apps install and render:
+
+- [app-stacks](https://github.com/BreadchainCoop/app-stacks) (Saving Circles)
+- [breadcoop-landing](https://github.com/BreadchainCoop/breadcoop-landing)
+- [crowdstaking-v2](https://github.com/BreadchainCoop/crowdstaking-v2)
+
+Because multiple apps depend on it, **the public API is a contract.** A careless rename or
+prop change here breaks downstream apps. Treat every exported component, prop, and type as
+public unless you can confirm nothing imports it. See [Guardrails](#guardrails--do-not-do-these).
+
+## Tech stack
+
+| Area             | Choice                                                             |
+| ---------------- | ------------------------------------------------------------------ |
+| Language         | TypeScript (strict)                                                |
+| UI               | React 18 (`react`/`react-dom` are **peer** deps, `>=16.8`)         |
+| Styling          | Tailwind CSS v4 — exposed via a preset + `theme.css`               |
+| Build            | [tsup](https://tsup.egoist.dev/) — **ESM-only, unbundled** for RSC |
+| Docs / preview   | Storybook 9 (`*.stories.tsx`)                                      |
+| Web3 (peer deps) | wagmi v2, viem v2, RainbowKit v2, Privy, TanStack Query v5         |
+| Icons (peer dep) | `@phosphor-icons/react`                                            |
+| Lint             | ESLint (typescript-eslint + react + react-hooks + storybook)       |
+| Package manager  | **npm** (the repo is locked with `package-lock.json`)              |
+
+The web3 / React libraries are **peer dependencies** on purpose — the consumer app owns
+those instances so there is exactly one wagmi/viem/React in the tree. Do not move them into
+`dependencies`. See [docs/ARCHITECTURE.md](./docs/ARCHITECTURE.md) for why and how the build
+preserves React Server Component support.
+
+## Repository map
+
+```
+src/
+  index.ts            Public entry — the barrel that defines the package's API surface
+  components/         One folder per component; each re-exports via index.ts
+    buttons/          Button (app-themed), CopyButtonIcon
+    LiftedButton/     Animated "lifted" button + presets (being phased out downstream)
+    typography/       Typography + Heading1-5, Body, Caption, FormattedDecimalNumber
+    navbar/ footer/   Layout chrome
+    auth/             Login buttons (Privy + general wallet variants)
+    connected-user/   ConnectedUserProvider + useConnectedUser (wallet/user state)
+    chip/ Logo/ loading-icon
+  context/            BreadUIKitProvider — app theme + token config context
+  hooks/              use-bread-balance, use-copy-to-clipboard, ... (one concern each)
+  utils/              cn, formatter, truncate-address, copy-to-clipboard, cssValidation
+  interface/          Shared types (e.g. App = "fund" | "stacks" | "net")
+  constansts/         Static data (links, tools) — note the existing spelling
+  fonts/              Pogaca .woff2 files + fonts.css
+  assets/             Images bundled into stories/components
+theme.css             Tailwind v4 theme + @font-face — published as @breadcoop/ui/theme
+tailwind-preset.js    Brand colors + font families — published as @breadcoop/ui/tailwind-preset
+tsup.config.ts        Build config (ESM, unbundled, dts)
+.storybook/           Storybook config
+dist/                 Build output (gitignored; published to npm)
+```
+
+For a one-line index of every public export (components, providers, hooks, utils, types),
+see **[docs/COMPONENTS.md](./docs/COMPONENTS.md)** — check it before adding a component here
+or in a consumer app to avoid rebuilding something that already ships.
+
+## Setup & commands
+
+This repo uses **npm**. Do not use pnpm or yarn here (it would desync `package-lock.json`).
+
+```bash
+npm install            # install deps
+npm run dev            # tsup --watch: rebuild dist/ on change (for local linking)
+npm run build          # build dist/ (tsup) + copy theme.css, preset, fonts
+npm run storybook      # Storybook dev server on http://localhost:6006
+npm run build-storybook
+npm run lint           # ESLint over src
+npm run lint:fix       # ESLint --fix
+npm run type-check     # tsc --noEmit (strict)
+npm test               # jest (see note below — no tests exist yet)
+```
+
+### Testing changes inside a consumer app
+
+There is no app to "run" here. To verify a change end-to-end, link the package into a
+consumer app (app-stacks, etc.):
+
+```bash
+# in bread-ui-kit
+npm run build              # or `npm run dev` to rebuild on save
+# in the consumer app's package.json
+#   "@breadcoop/ui": "file:../bread-ui-kit"
+# then reinstall in the consumer app
+```
+
+Then exercise the changed component in that app or in Storybook.
+
+## Verification — how to check your work
+
+This project has **no automated test suite** (the `test` script points at jest, but there
+are zero test files). Do not claim a change "passes tests." The required gates before
+considering work done are:
+
+1. `npm run lint` — must be clean (no errors).
+2. `npm run type-check` — `tsc --noEmit` must pass (strict mode).
+3. `npm run build` — must succeed, including `.d.ts` generation.
+4. For any visual or behavioral change, view the component in **Storybook**
+   (`npm run storybook`) and describe what you checked. If you add or change a component,
+   add or update its `*.stories.tsx`.
+
+If you add non-trivial logic (a util/hook), consider adding a test even though none exist
+yet, and say so — but the gates above are the baseline that must pass.
+
+## Conventions (follow the existing code)
+
+This library was written over time and the style is **not uniform** — some folders use tabs
++ kebab-case files (`components/buttons/`), others use 2-space indent + PascalCase files
+(`components/typography/`, `components/Logo/`). **Match the file and folder you are editing**
+rather than imposing one global style. When creating a new component folder, pick the
+closest existing sibling as your template.
+
+- **Public API lives in `src/index.ts`.** A new component is not usable by consumers until
+  it is exported there (usually via the folder's `index.ts` barrel). Keep exports explicit
+  and named; preserve existing export names — renaming one is a breaking change. When you
+  add or remove an export, update the index in [docs/COMPONENTS.md](./docs/COMPONENTS.md).
+- **Imports are relative** (`../../utils`, `./LiftedButtonPresets`). There is no `@/` path
+  alias configured — do not introduce one.
+- **Server vs client:** files that use hooks, state, effects, event handlers, browser APIs,
+  or wallet/Privy context **must start with `"use client"`**. The unbundled build preserves
+  this directive per-file so consumer apps can keep RSC working — **never remove a
+  `"use client"` directive** and add one to any new interactive component. Keep purely
+  presentational components server-compatible (no directive, no browser-only APIs at module
+  scope).
+- **Styling:** Tailwind utility classes using the brand tokens from `tailwind-preset.js`
+  (e.g. `bg-core-orange`, `text-surface-ink`, `font-breadDisplay`). Merge/condition classes
+  with the `cn` helper (`src/utils/cn.ts`) — never hand-concatenate `className` strings for
+  conditional logic. Do not hardcode hex colors that already exist as tokens.
+- **App theming:** several components are themed by app via the `App` type
+  (`"fund" | "stacks" | "net"`) and `BreadUIKitProvider` (`src/context/lib.tsx`). When a
+  component varies by app, read it from context / the `app` prop — don't fork the component.
+- **TypeScript:** strict mode is on. Avoid `any`; prefer `unknown` + narrowing. Export the
+  props type for any public component (e.g. `ButtonProps`, `LiftedButtonProps`). Unused
+  vars/args must be prefixed with `_` or removed (ESLint enforces this).
+- **Peer-dependency imports** (`wagmi`, `viem`, `react`, `@phosphor-icons/react`, …) are
+  fine to import — they resolve from the consumer app. Adding a brand-new peer dep is a
+  breaking change for consumers; flag it.
+- **Fonts/theme:** the brand fonts and `@font-face` rules live in `theme.css` /
+  `src/fonts/`. See [FONTS.md](./FONTS.md) before touching font wiring.
+
+## Guardrails — do not do these
+
+- **Do not break the public API silently.** Renaming/removing an export, renaming a prop,
+  or changing a prop's type/default can break app-stacks, breadcoop-landing, and
+  crowdstaking-v2. If a change is breaking, say so explicitly and bump the version per
+  [semver](https://semver.org/) (`major` for breaking) — see [CONTRIBUTING.md](./CONTRIBUTING.md).
+- **Do not move peer dependencies** (`react`, `wagmi`, `viem`, `@rainbow-me/rainbowkit`,
+  `@privy-io/react-auth`, `@tanstack/react-query`, `@phosphor-icons/react`) into
+  `dependencies`, and don't add heavy runtime deps. The consumer app must own those
+  instances (one React, one wagmi).
+- **Do not remove `"use client"` directives** or change the build to bundle output
+  (`bundle: false` and ESM-only in `tsup.config.ts` are required for RSC support).
+- **Do not edit `dist/`** by hand — it is generated by `npm run build` and gitignored.
+- **Do not reformat or refactor code unrelated to your change**, and do not "normalize" the
+  indentation of a file you're only making a small edit to.
+- **Do not delete pre-existing dead/commented code** unless asked — mention it instead.
+- **Do not** commit secrets or `.env*` files.
+
+## Pull requests
+
+- Branch from and target **`main`** (this repo's default branch).
+- Use **Conventional Commits** (`feat:`, `fix:`, `chore:`, `refactor:`, `docs:`…) and
+  reference the issue number when fixing one.
+- If your change touches the public API, bump `version` in `package.json` and note the
+  breaking/non-breaking impact in the PR description.
+- Keep PRs focused; describe what you changed and how you verified it (the gates above +
+  what you saw in Storybook / a consumer app).
+
+Full workflow details: [CONTRIBUTING.md](./CONTRIBUTING.md).
+Build/export internals: [docs/ARCHITECTURE.md](./docs/ARCHITECTURE.md).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,97 @@
+# CLAUDE.md
+
+Guidance for Claude Code working in this repo.
+
+**Project context — read first:** all stack, architecture, commands, conventions, and
+guardrails live in **[AGENTS.md](./AGENTS.md)** (the canonical agent doc, shared with
+Cursor/Copilot/Codex). Deeper references: [docs/COMPONENTS.md](./docs/COMPONENTS.md) (index
+of every public export), [docs/ARCHITECTURE.md](./docs/ARCHITECTURE.md),
+[CONTRIBUTING.md](./CONTRIBUTING.md), and [FONTS.md](./FONTS.md).
+
+The rest of this file is the behavioral playbook: _how_ to work, not _what_ the project
+is. These are general rules to reduce common LLM coding mistakes.
+
+**This is a shared library.** Other apps depend on its public API, so the bias toward
+caution below matters more here than in a normal app: a "small cleanup" can be a breaking
+change for three downstream apps. For trivial tasks, use judgment.
+
+## 1. Think Before Coding
+
+**Don't assume. Don't hide confusion. Surface tradeoffs.**
+
+Before implementing:
+
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them — don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
+- **Before changing anything exported from `src/index.ts`, ask:** will this rename, remove,
+  or retype something a consumer app imports? If yes, it's a breaking change — flag it.
+
+## 2. Simplicity First
+
+**Minimum code that solves the problem. Nothing speculative.**
+
+- No features beyond what was asked.
+- No new props, variants, or "configurability" that wasn't requested — every prop you add
+  is API surface this library must support forever.
+- No abstractions for single-use code.
+- No error handling for impossible scenarios.
+- If you write 200 lines and it could be 50, rewrite it.
+
+Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
+
+## 3. Surgical Changes
+
+**Touch only what you must. Clean up only your own mess.**
+
+When editing existing code:
+
+- Don't "improve" adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken, and **don't normalize indentation** — this repo
+  mixes tabs and spaces across folders on purpose-by-history; match the file you're in.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated dead code, mention it — don't delete it.
+
+When your changes create orphans:
+
+- Remove imports/variables/functions that YOUR changes made unused.
+- Don't remove pre-existing dead code unless asked.
+
+The test: Every changed line should trace directly to the user's request.
+
+## 4. Goal-Driven Execution
+
+**Define success criteria. Loop until verified.**
+
+This repo has **no automated test suite**, so verification means the gates in
+[AGENTS.md](./AGENTS.md#verification--how-to-check-your-work):
+
+- `npm run lint` clean, `npm run type-check` passes, `npm run build` succeeds.
+- For any visual/behavioral change, view it in **Storybook** (`npm run storybook`) and add
+  or update the component's `*.stories.tsx`. For integration concerns, link the package into
+  a consumer app and check it there.
+
+Transform tasks into verifiable goals:
+
+- "Add a variant" → "Define the variant; confirm it renders in Storybook and types compile."
+- "Fix the bug" → "Reproduce it in a story, fix it, confirm the repro no longer triggers."
+- "Refactor X" → "Confirm lint + type-check + build pass and the public API is unchanged
+  (or the change is intentionally versioned)."
+
+For multi-step tasks, state a brief plan:
+
+```text
+1. [Step] → verify: [check]
+2. [Step] → verify: [check]
+3. [Step] → verify: [check]
+```
+
+Strong success criteria let you loop independently. Weak criteria ("make it work")
+require constant clarification.
+
+---
+
+**These guidelines are working if:** fewer unnecessary changes in diffs, fewer accidental
+breaking changes to the public API, fewer rewrites due to overcomplication, and clarifying
+questions come before implementation rather than after mistakes.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,107 @@
+# Contributing to Bread UI Kit
+
+Thanks for contributing to `@breadcoop/ui`, the shared component library behind the Bread
+Coop frontend ([app-stacks](https://github.com/BreadchainCoop/app-stacks),
+[breadcoop-landing](https://github.com/BreadchainCoop/breadcoop-landing),
+[crowdstaking-v2](https://github.com/BreadchainCoop/crowdstaking-v2)).
+
+This is the **human** guide. AI coding agents should read [AGENTS.md](./AGENTS.md) (and
+Claude Code reads [CLAUDE.md](./CLAUDE.md)); the architecture is in
+[docs/ARCHITECTURE.md](./docs/ARCHITECTURE.md). Everything here is consistent with those.
+
+## Getting started
+
+This repo uses **npm** (it's locked with `package-lock.json` — don't use pnpm/yarn).
+
+```bash
+git clone https://github.com/BreadchainCoop/bread-ui-kit.git
+cd bread-ui-kit
+npm install
+npm run storybook        # http://localhost:6006 — the main dev surface
+```
+
+There's no app to run — you build and preview components in **Storybook**.
+
+## Common commands
+
+| Command                   | What it does                                      |
+| ------------------------- | ------------------------------------------------- |
+| `npm run storybook`       | Storybook dev server (develop/preview components) |
+| `npm run dev`             | `tsup --watch` — rebuild `dist/` on change        |
+| `npm run build`           | Build `dist/` + copy theme/preset/fonts           |
+| `npm run lint`            | ESLint                                            |
+| `npm run lint:fix`        | ESLint with `--fix`                               |
+| `npm run type-check`      | `tsc --noEmit` (strict)                           |
+| `npm run build-storybook` | Static Storybook build                            |
+
+## Developing a component in a real app
+
+To see a change inside a consumer app before publishing, link the package locally:
+
+1. In a consumer app's `package.json`, point the dependency at your local checkout:
+   ```json
+   { "dependencies": { "@breadcoop/ui": "file:../bread-ui-kit" } }
+   ```
+2. In `bread-ui-kit`, run `npm run dev` (rebuilds on save).
+3. Reinstall in the consumer app and exercise the component there.
+
+## Before you open a PR
+
+There is **no automated test suite**. The required checks are:
+
+1. `npm run lint` — clean.
+2. `npm run type-check` — passes (strict).
+3. `npm run build` — succeeds (including `.d.ts` generation).
+4. Component verified in **Storybook**. If you add or change a component, add/update its
+   `*.stories.tsx`.
+
+## The public API is a contract
+
+Three apps depend on this package, so what you export is a contract:
+
+- New components must be exported from `src/index.ts` (usually via a folder `index.ts`),
+  with their props type exported too (e.g. `ButtonProps`).
+- **Renaming or removing an export, renaming a prop, or changing a prop's type/default is a
+  breaking change.** Avoid it when you can; when you must, call it out explicitly.
+- Keep React/web3 libraries as **peer dependencies**. Adding a new peer dep or a heavy
+  runtime dep affects every consumer — flag it in the PR.
+
+See [docs/ARCHITECTURE.md](./docs/ARCHITECTURE.md) for why the build is ESM-only and
+unbundled, and why `"use client"` directives must be preserved for RSC support.
+
+## Versioning & releases
+
+This package follows [semver](https://semver.org/):
+
+- **patch** — bug fix, no API change.
+- **minor** — new component/prop, backward compatible.
+- **major** — breaking change to the public API.
+
+Bump `version` in `package.json` as part of the PR when your change is user-facing. The
+`prepublishOnly` script runs `npm run build`, so publishing always builds fresh `dist/`.
+
+## Coding conventions
+
+Follow the existing code. A few specifics (full list in [AGENTS.md](./AGENTS.md)):
+
+- Match the style of the folder you're editing — this codebase mixes tab/space indentation
+  and kebab/PascalCase filenames across folders by history. Don't reformat unrelated code.
+- Use the brand Tailwind tokens (`tailwind-preset.js`) and the `cn` helper for class merging.
+- Add `"use client"` to any interactive component (hooks/state/effects/handlers/wallet);
+  keep presentational components server-safe. Never remove an existing `"use client"`.
+- TypeScript strict: avoid `any`, prefix unused vars with `_`.
+
+## Commits & branches
+
+- Branch from and target **`main`**.
+- Use [Conventional Commits](https://www.conventionalcommits.org/): `feat:`, `fix:`,
+  `chore:`, `refactor:`, `docs:`, `style:`, `test:` — reference an issue number when one
+  exists.
+- Keep PRs focused. Describe what changed, the API impact (breaking or not), and how you
+  verified it.
+
+## Design-driven work
+
+New components and design-system updates usually start from a design issue — see the
+[Design Issue template](./.github/ISSUE_TEMPLATE/design.md). Link the Figma file and confirm
+the required variants/states before implementing.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Preview the available typography and components on the [Storybook Demo](http://b
 
 3. **Use components** in your React app:
    ```tsx
-   import { LiftedButton, Heading1, Body } from "@breadcoop/ui";
+   import { Button, Heading1, Body } from "@breadcoop/ui";
    import "./globals.css"; // Make sure to import your CSS file i.e. in layout.ts
    ```
 
@@ -46,7 +46,7 @@ Preview the available typography and components on the [Storybook Demo](http://b
 
 ```tsx
 import React from "react";
-import { LiftedButton, Heading1, Body } from "@breadcoop/ui";
+import { Button, Heading1, Body } from "@breadcoop/ui";
 import "./globals.css";
 
 function App() {
@@ -54,9 +54,7 @@ function App() {
     <div>
       <Heading1>Welcome to Bread Coop</Heading1>
       <Body>This text uses our brand typography.</Body>
-      <LiftedButton preset="primary" onClick={() => console.log("Clicked!")}>
-        Click me
-      </LiftedButton>
+      <Button onClick={() => console.log("Clicked!")}>Click me</Button>
 
       {/* Tailwind classes available in imported theme can be used */}
       <div className="bg-primary-orange text-white p-4 rounded-md">
@@ -68,6 +66,11 @@ function App() {
 ```
 
 ## Components
+
+The sections below cover the most common components. For a one-line index of **everything**
+the package exports — components, providers, hooks, utils, and types — see
+[docs/COMPONENTS.md](./docs/COMPONENTS.md), or browse the
+[Storybook demo](http://breadcoopstorybook.netlify.app/).
 
 ### Typography
 
@@ -106,80 +109,88 @@ import { Heading1, Heading2, Heading3, Body, Caption } from "@breadcoop/ui";
 | Body                | `className?: string`                                                   | Additional CSS classes          |
 | Body                | `bold?: boolean`                                                       | Make text bold (default: false) |
 
-### LiftedButton
+### Button
+
+The primary, app-themed button. It is polymorphic (`as`), brand-aware (`app`), and
+supports left/right icons and a loading state.
 
 ```tsx
-import { LiftedButton } from "@breadcoop/ui";
+import { Button } from "@breadcoop/ui";
 
-<Typography variant="h1">Main Heading</Typography>
-<Typography variant="h2">Section Heading</Typography>
-<Typography variant="body">Body text content</Typography>
-<Typography variant="caption">Small caption text</Typography>
+<Button>Primary</Button>
+<Button variant="secondary">Secondary</Button>
+<Button variant="light">Cancel</Button>
 ```
 
 #### Props
 
-| Prop           | Type                                                                | Default   | Description                         |
-| -------------- | ------------------------------------------------------------------- | --------- | ----------------------------------- |
-| children       | React.ReactNode                                                     | -         | The content of the button           |
-| preset         | 'primary' \| 'secondary' \| 'destructive' \| 'positive' \| 'stroke' | 'primary' | The preset style of the button      |
-| leftIcon       | React.ReactNode                                                     | -         | Icon to display on the left side    |
-| rightIcon      | React.ReactNode                                                     | -         | Icon to display on the right side   |
-| disabled       | boolean                                                             | false     | Whether the button is disabled      |
-| colorOverrides | Partial<LiftedButtonColors>                                         | {}        | Override specific colors            |
-| offsetPx       | number                                                              | 4         | Pixel offset for the lifted effect  |
-| durationMs     | number                                                              | 300       | Transition duration in milliseconds |
-| width          | 'full' \| 'auto' \| 'mobile-full'                                   | 'auto'    | Button width behavior               |
-| scrollTo       | string                                                              | -         | Element ID to scroll to on click    |
-| className      | string                                                              | ''        | Additional CSS classes              |
-| type           | 'button' \| 'submit' \| 'reset'                                     | 'button'  | Button type                         |
-| onClick        | () => void                                                          | -         | Click handler                       |
+| Prop                    | Type                                                                         | Default   | Description                                           |
+| ----------------------- | ---------------------------------------------------------------------------- | --------- | ----------------------------------------------------- |
+| children                | React.ReactNode                                                              | -         | The content of the button                             |
+| app                     | 'fund' \| 'stacks' \| 'net'                                                  | 'fund'    | Brand theme: fund = orange, stacks = blue, net = jade |
+| variant                 | 'primary' \| 'secondary' \| 'destructive' \| 'positive' \| 'light' \| 'burn' | 'primary' | Visual style                                          |
+| size                    | 'sm' \| 'default' \| 'icon'                                                  | 'default' | Padding / sizing (`icon` is square)                   |
+| leftIcon                | React.ReactNode                                                              | -         | Icon rendered before the children                     |
+| rightIcon               | React.ReactNode                                                              | -         | Icon rendered after the children                      |
+| isLoading               | boolean                                                                      | false     | Show a loading spinner and disable the button         |
+| showChildrenWhenLoading | boolean                                                                      | false     | Keep the children visible while loading               |
+| withBorder              | boolean                                                                      | false     | Add a `surface-ink` border (non-`light` variants)     |
+| as                      | ElementType                                                                  | 'button'  | Render as another element/component (e.g. `'a'`)      |
+| disabled                | boolean                                                                      | false     | Whether the button is disabled                        |
+| className               | string                                                                       | -         | Additional CSS classes (merged with `cn`)             |
 
-#### Presets
+Any other props are forwarded to the underlying element, so native attributes like
+`onClick`, `type`, and `href` (with `as="a"`) work as expected.
 
-- **primary**: Orange background with white text
-- **secondary**: Light orange background with orange text
-- **stroke**: White background with dark text and border
+#### Variants
+
+- **primary**: solid brand color (orange / blue / jade depending on `app`).
+- **secondary**: lighter tinted background with brand-colored text.
+- **light**: paper background with dark ink text and a border.
+- **destructive**: red — for irreversible/dangerous actions.
+- **positive**: green — for confirming/successful actions.
+- **burn**: red-tinted background with red text.
 
 #### Examples
 
 ```tsx
-import { LiftedButton } from "@breadcoop/ui";
+import { Button } from "@breadcoop/ui";
 import { ArrowUpRight, SignOut } from "@phosphor-icons/react";
 
 // Basic usage
-<LiftedButton>Click me</LiftedButton>
+<Button>Click me</Button>
 
-// With presets
-<LiftedButton preset="primary">Primary Button</LiftedButton>
-<LiftedButton preset="secondary">Secondary Button</LiftedButton>
-<LiftedButton preset="stroke">Cancel</LiftedButton>
+// Variants
+<Button variant="primary">Primary Button</Button>
+<Button variant="secondary">Secondary Button</Button>
+<Button variant="light">Cancel</Button>
+<Button variant="destructive">Delete</Button>
+
+// App theme (orange / blue / jade)
+<Button app="stacks">Stacks Button</Button>
+
+// Sizes
+<Button size="sm">Small</Button>
+<Button size="icon" aria-label="Open"><ArrowUpRight /></Button>
 
 // With icons
-<LiftedButton leftIcon={<ArrowUpRight />}>External Link</LiftedButton>
-<LiftedButton rightIcon={<SignOut />}>Sign Out</LiftedButton>
+<Button leftIcon={<ArrowUpRight />}>External Link</Button>
+<Button rightIcon={<SignOut />}>Sign Out</Button>
 
-// Full width
-<LiftedButton width="full">Full Width Button</LiftedButton>
+// Loading state
+<Button isLoading>Saving…</Button>
+<Button isLoading showChildrenWhenLoading>Saving…</Button>
 
-// Mobile full width (full on mobile, auto on desktop)
-<LiftedButton width="mobile-full">Responsive Button</LiftedButton>
-
-// Custom offset and duration
-<LiftedButton offsetPx={8} durationMs={500}>
-  Custom Animation
-</LiftedButton>
-
-// Scroll to element
-<LiftedButton scrollTo="contact-section">
-  Contact Us
-</LiftedButton>
+// Render as a link
+<Button as="a" href="https://breadchain.xyz" target="_blank">
+  Visit site
+</Button>
 
 // Disabled state
-<LiftedButton disabled>Disabled Button</LiftedButton>
+<Button disabled>Disabled Button</Button>
 ```
 
-#### Logo Component
+### Logo
 
 ```tsx
 import { Logo } from '@breadcoop/ui';

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,105 @@
+# Architecture
+
+How `@breadcoop/ui` is structured, built, and consumed. Read this before changing the
+build, the exports, or anything touching React Server Components. For day-to-day rules see
+[AGENTS.md](../AGENTS.md).
+
+## The shape of the package
+
+This is a **pure component library** — no app shell, no server, no routes. Everything is
+authored in `src/` and compiled into `dist/`, which is what npm publishes.
+
+The package exposes four things to consumers (see `exports` in `package.json`):
+
+| Import path                     | What it is                                            |
+| ------------------------------- | ----------------------------------------------------- |
+| `@breadcoop/ui`                 | The JS/TS API — components, hooks, utils, context     |
+| `@breadcoop/ui/theme`           | `theme.css` — Tailwind v4 import + `@font-face` rules |
+| `@breadcoop/ui/tailwind-preset` | `tailwind-preset.js` — brand colors + font families   |
+| `@breadcoop/ui/fonts`           | `fonts.css` + bundled `.woff2` font files             |
+
+`src/index.ts` is the **single public barrel**. If it isn't exported there (directly or via
+a folder `index.ts`), consumers can't import it. Adding an export grows the public API;
+removing/renaming one is a breaking change.
+
+## Build: ESM-only, unbundled (for RSC)
+
+The build is [tsup](https://tsup.egoist.dev/) (`tsup.config.ts`). Two non-negotiable
+choices make this library safe to use inside React Server Component apps like
+[app-stacks](https://github.com/BreadchainCoop/app-stacks):
+
+```ts
+format: ["esm"],   // ESM only — no CJS
+bundle: false,     // compile each source file to its own dist file, 1:1
+```
+
+Why this matters:
+
+- **`bundle: false` preserves per-file `"use client"` directives.** A bundler would merge
+  modules and collapse or strip those directives, which would force the consumer's entire
+  import to become client-side (or break the RSC boundary entirely). By emitting one output
+  file per source file, each component keeps its own `"use client"` (or stays server-safe),
+  so Next.js can split the boundary correctly. **This is the reason you must never delete a
+  `"use client"` directive or re-enable bundling.**
+- **ESM-only** matches modern Next.js / RSC consumers and keeps a single module graph.
+- **`esbuild-fix-imports-plugin`** rewrites relative imports to include file extensions,
+  which unbundled ESM requires to resolve correctly.
+- **`dts: true`** emits `.d.mts` type declarations next to the JS, with `declarationMap`
+  for go-to-definition into source.
+
+The `build` script then runs `copy-files` to place `theme.css`, `tailwind-preset.js`, and
+the `fonts/` directory into `dist/` so the non-JS entry points resolve.
+
+> `dist/` is **gitignored** and generated. Never edit it by hand; never commit it.
+
+## Theming model
+
+Brand styling is delivered as Tailwind v4 config + CSS, not as bundled CSS-in-JS:
+
+- **`tailwind-preset.js`** defines the brand color tokens (`core-orange`, `primary-blue`,
+  `surface-ink`, `paper-main`, …) and font families (`breadDisplay`, `breadBody`,
+  `roboto`). Consumers add it as a Tailwind preset, or it's pulled in via `theme.css`.
+- **`theme.css`** imports Tailwind and declares the Pogaca `@font-face` rules pointing at
+  the bundled fonts. Consumers `@import "@breadcoop/ui/theme";` in their global CSS.
+- Components reference these tokens through Tailwind utility classes (`bg-core-orange`,
+  `font-breadDisplay`, …), composed safely with the `cn` helper (`src/utils/cn.ts`,
+  `clsx` + `tailwind-merge`).
+
+### App-aware components
+
+Some components render differently per consuming app. The app identity is the `App` type
+(`"fund" | "stacks" | "net"`, `src/interface/app.ts`) provided through `BreadUIKitProvider`
+(`src/context/lib.tsx`) along with `chainId` and a `tokenConfig` (e.g. the BREAD token
+address/ABI). Components read the active app from context (or an `app` prop) and switch
+classes accordingly — see `src/components/buttons/button.tsx` for the canonical pattern.
+Prefer extending that switch over forking a component per app.
+
+## Web3 & React as peer dependencies
+
+`react`, `react-dom`, `wagmi`, `viem`, `@rainbow-me/rainbowkit`, `@privy-io/react-auth`,
+`@tanstack/react-query`, and `@phosphor-icons/react` are **peer dependencies**, not
+bundled dependencies. The consuming app installs and owns them, guaranteeing a single
+instance of React, wagmi, and viem across the tree (multiple copies cause hook errors and
+broken wallet state). The library's own runtime deps are intentionally tiny: `clsx`,
+`tailwind-merge`, and `@radix-ui/react-navigation-menu`.
+
+**Implication for changes:** importing from a peer dep is fine. Requiring a *new* peer dep,
+or moving a peer dep into `dependencies`, changes what every consumer must install — treat
+it as a breaking change and flag it.
+
+## Storybook = the dev surface
+
+There's no app to run, so [Storybook](https://storybook.js.org/) (`.storybook/`, Storybook
+9 with the Vite builder) is where components are developed and verified. Stories live next
+to components as `*.stories.tsx`. New or changed components should come with a story; it's
+the primary way to confirm a visual/behavioral change without a downstream app.
+
+## Map: source → output
+
+```
+src/index.ts                →  dist/index.mjs  + dist/index.d.mts   (public API)
+src/components/**/*.tsx      →  dist/components/**/*.mjs (+ .d.mts)   (1:1, unbundled)
+theme.css                   →  dist/theme.css            (copied)
+tailwind-preset.js          →  dist/tailwind-preset.js   (copied)
+src/fonts/                  →  dist/fonts/               (copied)
+```

--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -1,0 +1,93 @@
+# Component & API index
+
+A one-line catalog of everything `@breadcoop/ui` exports, so you can check whether
+something already exists **before building it in a consumer app**
+([app-stacks](https://github.com/BreadchainCoop/app-stacks),
+[breadcoop-landing](https://github.com/BreadchainCoop/breadcoop-landing),
+[crowdstaking-v2](https://github.com/BreadchainCoop/crowdstaking-v2)).
+
+This is a discovery aid, not full documentation. The **sources of truth** for exact props
+and behavior are:
+
+- **Storybook** — live, visual prop playground (`npm run storybook`, or the
+  [hosted demo](http://breadcoopstorybook.netlify.app/)).
+- **The shipped types** — `@breadcoop/ui`'s `.d.mts` declarations give exact, always-in-sync
+  prop/return types via your editor's autocomplete.
+- **`src/index.ts`** — the single barrel that defines the public API. If it isn't exported
+  there, it's internal — don't import it via deep paths.
+
+> Keep this file in sync with `src/index.ts` when you add or remove an export.
+
+## Setup (required first)
+
+Most components and all hooks read app config from context. Wrap your app once at the root:
+
+- **`BreadUIKitProvider`** — supplies `app` (`"fund" | "stacks" | "net"`), `chainId`,
+  `tokenConfig` (the BREAD token `address` + `abi`), and `authProvider`
+  (`"privy" | "general"`). App-aware components and `useBreadBalance` won't work without it.
+  — `src/context/lib.tsx`
+- **`ConnectedUserProvider`** — provides wallet/user connection state to `useConnectedUser`;
+  picks the Privy or general-wallet implementation based on `authProvider`. Nest inside
+  `BreadUIKitProvider`. — `src/components/connected-user/provider.tsx`
+
+## Components
+
+- **`Typography`** — single component switching brand styles by `variant`
+  (`h1`–`h5`, `body`, `caption`). — `src/components/typography/Typography.tsx`
+- **`Heading1`–`Heading5`, `Body`, `Caption`** — named shortcuts for the typography variants
+  (`Body` also takes `bold`). — `src/components/typography/Typography.tsx`
+- **`FormattedDecimalNumber`** — renders a number with the integral/decimal parts styled
+  separately, plus an optional BREAD icon and `unit`. — `src/components/typography/formatted-dec-num.tsx`
+- **`Button`** — primary app-themed button (`variant`, `size`, icons, `isLoading`,
+  polymorphic `as`). The main button; see README + Storybook. — `src/components/buttons/button.tsx`
+- **`CopyButtonIcon`** — icon button that copies `textToCopy` to the clipboard and shows a
+  check on success. — `src/components/buttons/copy-icon.tsx`
+- **`LiftedButton`** — animated "lifted" button with presets. **Being phased out downstream**
+  — prefer `Button` for new work. — `src/components/LiftedButton/LiftedButton.tsx`
+- **`Logo`** — Bread Coop logo; `variant` (`square`/`line`), `color`, `size`, optional `text`.
+  — `src/components/Logo/Logo.tsx`
+- **`Chip`** — small pill/badge; `size` (`small`/`regular`), optional `icon`.
+  — `src/components/chip/chip.tsx`
+- **`LoadingIcon`** — circular spinner tinted by `app`. — `src/components/loading-icon.tsx`
+- **`Navbar`** — top navigation bar; takes `app`, your framework's `Link` component
+  (next/link, react-router…), and `widgetItems`/`actionItems` for the account area.
+  — `src/components/navbar/navbar.tsx`
+- **`NavSolidarityApps` / `NavSolidarityAppsDesktop`** — the "solidarity apps" switcher menu
+  (mobile / desktop layouts). — `src/components/navbar/solidarity-apps.tsx`
+- **`NavAccountWidgetItem`** — a labeled icon row used inside the navbar account widget.
+  — `src/components/navbar/account-widget-item.tsx`
+- **`Footer`** — site footer with social links and solidarity-tool links.
+  — `src/components/footer/footer.tsx`
+- **`LoginButton`** — sign-in button; renders the Privy or general-wallet variant based on
+  `authProvider` from context. — `src/components/auth/login-button.tsx`
+
+## Providers & context
+
+- **`BreadUIKitProvider`** — see [Setup](#setup-required-first). — `src/context/lib.tsx`
+- **`ConnectedUserProvider`** — see [Setup](#setup-required-first).
+  — `src/components/connected-user/provider.tsx`
+- **`useConnectedUser()`** — returns the connection state machine: `TUserLoading` /
+  `TUserNotConnected` / `TUserConnected` (`status` is `LOADING` / `NOT_CONNECTED` /
+  `CONNECTED` / `UNSUPPORTED_CHAIN`). — `src/components/connected-user/context.ts`
+
+## Hooks
+
+- **`useBreadBalance({ address })`** — reads the BREAD ERC-20 balance via wagmi, auto-refetches
+  each block. Returns `{ BREAD, refetchBalance, isLoading }`. Requires `BreadUIKitProvider`.
+  — `src/hooks/use-bread-balance.ts`
+- **`useCopyToClipboard({ textToCopy })`** — returns `{ copied, copy }`; `copied` flips back
+  to `false` shortly after a copy. — `src/hooks/use-copy-to-clipboard.ts`
+
+## Utils
+
+- **`cn(...classes)`** — combine/merge Tailwind class strings (clsx + tailwind-merge). Use
+  this for all conditional `className` logic. — `src/utils/cn.ts`
+- **`formatBalance(value, decimals = 2)`** — format a number with grouping and fixed decimals
+  (`Intl.NumberFormat`). — `src/utils/formatter.ts`
+
+## Exported types
+
+`ButtonProps`, `LiftedButtonProps`, `LogoProps`, `LogoColor`, `LogoVariant`,
+`TConnectedUserState`, `TUserConnected`, `TUserLoading`, `TUserNotConnected`, and the
+`fontVariables` constant (the brand font CSS-variable names) are all exported from
+`@breadcoop/ui` for use in consumer code.


### PR DESCRIPTION
…eference docs

Set up instructions so coding agents can contribute to the library:

- AGENTS.md: canonical, tool-agnostic project context (stack, repo map, npm commands, verification gates, conventions, guardrails, PR rules).
- CLAUDE.md: behavioral playbook (Karpathy principles) pointing to AGENTS.md.
- CONTRIBUTING.md: human-facing setup, local-linking, semver, and PR workflow.
- docs/ARCHITECTURE.md: ESM-only/unbundled build, RSC "use client" handling, theming model, peer-dependency rationale.
- docs/COMPONENTS.md: one-line index of every public export for discovery, wired into AGENTS.md/CLAUDE.md/README.
- README: replace LiftedButton docs with Button, promote Logo to its own section, and standardize markdown table formatting.